### PR TITLE
[WASH-931] Add share method to iOS plugin

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -54,7 +54,6 @@ class _MyAppState extends State<MyApp> {
     });
   }
 
-
   void onWriteRecordButtonPress() async {
     var creds = ClientCredentials(apiKey: "",
                                   apiSecret: "",
@@ -95,6 +94,29 @@ class _MyAppState extends State<MyApp> {
       developer.log("example flow failed because $e");
     }
   }
+  
+  void onWriteThenShareRecordButtonPress() async {
+    var creds = ClientCredentials(apiKey: "", 
+                                  apiSecret: "",
+                                  clientId: "",
+                                  publicKey: "",
+                                  privateKey: "",
+                                  publicSignKey: "",
+                                  privateSigningKey: "",
+                                  host: "",
+                                  email: "",
+                                  clientName: "");
+    var client = PluginTozny(creds);
+    var recordType = "";
+    var readerID = "";
+    try {
+      Record writtenRecord = await writeRecord(client);
+      await share(client, recordType, readerID);
+      developer.log("write record succeeded");
+    } catch (e) {
+      developer.log("example share flow failed becaused $e");
+    }
+  }
 
   void onButtonPress() async {
     String registrationToken = "TOKEN_HERE";
@@ -129,6 +151,17 @@ class _MyAppState extends State<MyApp> {
       print(record.toJson().toString());
     } catch (e) {
       print("error $e");
+    }
+  }
+
+  Future<void> share(PluginTozny client, String type, String readerID) async {
+    try {
+      await client.share(type, readerID);
+      setState(() {
+        _platformVersion = "shared record: " + type;
+      });
+    } catch (e) {
+      developer.log("Share record failed becaues " + e.toString());
     }
   }
 

--- a/ios/Classes/SwiftFlutterPlugin.swift
+++ b/ios/Classes/SwiftFlutterPlugin.swift
@@ -26,6 +26,10 @@ public class SwiftFlutterPlugin: NSObject, Flutter.FlutterPlugin {
             }
         case "loginIdentity":
             self.loginIdentity(call, result: result)
+        case "share":
+            DispatchQueue.main.async {
+                self.share(call, result: result)
+            }
         default:
             result(FlutterMethodNotImplemented)
         }
@@ -94,6 +98,28 @@ public class SwiftFlutterPlugin: NSObject, Flutter.FlutterPlugin {
                     result(E3dbSerializer.recordToJson(record: record))
                 } else {
                     result(FlutterError(code: "READ_RECORD", message: "Read data record failed", details: nil))
+                }
+            }
+        }
+    }
+
+    // MARK: SHARE
+
+    // Shares a record type with another client using its ID 
+    public func share(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
+        let client: Client = self.initClientFromFlutter(call, result: result)!
+        let args = call.arguments as! Dictionary<String, Any>
+        let recordType = args["type"] as! String
+        let readerID = args["reader_id"] as! String
+        
+        let group = DispatchGroup()
+        group.enter()
+        DispatchQueue.global().async {
+            client.share(type: recordType, readerId: UUID(uuidString: readerID)!) { (shareResult) in
+                shareResult.analysis(ifSuccess: { voidResultFromShare in
+                    result(nil)
+                }) { error in
+                    result(FlutterError(code: "SHARE_ERROR", message: error.description, details: nil))
                 }
             }
         }


### PR DESCRIPTION
- Adds a share record method to iOS plugin
- Adds a new test to example app that writes then
  shares a record

Using this draft to communicate current progress on sharing records. 

`share` is confirmed to successfully share a record by running `onWriteThenShareRecordButtonPress` test in `main.dart` then confirming in dashboard and docker logs. 

The `shareResult` value returned in `share`'s callback returns a `cryptoError` object when sharing a new record type, which causes execution to fall into the `FlutterError` case. I confirmed that this was not an issue with re-sharing the same record given that doing so returns the expected `409` instead of a `cryptoError`.

I will mark in in-line comments where the callback returns a `cryptoError`.