### PR TITLE
[WASH-931] Fix DispatchGroup typo after rebase

### DIFF
--- a/ios/Classes/SwiftFlutterPlugin.swift
+++ b/ios/Classes/SwiftFlutterPlugin.swift
@@ -100,7 +100,9 @@ public class SwiftFlutterPlugin: NSObject, Flutter.FlutterPlugin {
                     result(FlutterError(code: "READ_RECORD", message: "Read data record failed", details: nil))
                 }
             }
+            group.leave()
         }
+        group.wait()
     }
 
     // MARK: SHARE
@@ -116,13 +118,15 @@ public class SwiftFlutterPlugin: NSObject, Flutter.FlutterPlugin {
         group.enter()
         DispatchQueue.global().async {
             client.share(type: recordType, readerId: UUID(uuidString: readerID)!) { (shareResult) in
-                shareResult.analysis(ifSuccess: { voidResultFromShare in
+                shareResult.analysis(ifSuccess: { (voidResultFromShare) in
                     result(nil)
                 }) { error in
                     result(FlutterError(code: "SHARE_ERROR", message: error.description, details: nil))
                 }
             }
+            group.leave()
         }
+        group.wait()
     }
 
     func emptyActionHandler(loginAction: E3db.IdentityLoginAction) -> [String:String] {


### PR DESCRIPTION
- Adds back in DispatchGroup waiting to block main
  thread execution for API requests that was inadvertantly
  removed after a merge

In my hubris I did not notice that my rebase removed main thread blocking by the dispatch group for read record and share record 🤦 

Both methods tested again and work