### PR TITLE
Wash 936 register tozid identity

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -159,6 +159,24 @@ class _MyAppState extends State<MyApp> {
     }
   }
 
+  void registerIdentityOnButtonPress() async {
+    String apiUrl = "";
+    String appName = "account";
+    String realmName = "";
+    String brokerTargetUrl = "https://id.tozny.com/example/recover";
+    String username = "";
+    String password = "";
+
+    try {
+      var realmCreds = RealmConfig(realmName: realmName, appName: appName, apiURL: apiUrl, brokerTargetURL: brokerTargetUrl);
+      var token = "";
+      await registerIdentityAndLogin(realmCreds, token);
+    } catch (e) {
+      developer.log("Example flow failed because $e");
+    }
+
+  }
+
   void registerIdentityAndLogin(RealmConfig config, String regToken) async {
     var realmClient = new PluginRealm(config);
     Random random = new Random();
@@ -172,6 +190,10 @@ class _MyAppState extends State<MyApp> {
       print("writing record with identity");
       var record = await writeRecord(loggedInIdentity.client);
       print(record.toJson().toString());
+      setState(() {
+        _platformVersion = "Registered identity, logged in, and wrote a record";
+      });
+
     } catch (e) {
       print("error $e");
     }

--- a/ios/Classes/E3dbSerializer.swift
+++ b/ios/Classes/E3dbSerializer.swift
@@ -17,6 +17,15 @@ public class E3dbSerializer {
         let jsonString = String(data: jsonData, encoding: .utf8)!
         return jsonString
     }
+    
+    static func partialIdClientToJson(id: PartialIdentity) -> String {
+        var data: [String: Any] = [:]
+        data.updateValue(E3dbSerializer.configToJson(storageConfig: FlutterConfig.decodeToFlutterConfig(e3dbConfig: id.idConfig.storageConfig)), forKey: "client_credentials")
+        data.updateValue(E3dbSerializer.idConfigToJson(idConfig: id.idConfig), forKey: "identity_config")
+        let jsonData = try! JSONSerialization.data(withJSONObject: data, options: .prettyPrinted)
+        let jsonString = String(data: jsonData, encoding: .utf8)!
+        return jsonString
+    }
 
     static func configToJson(storageConfig: FlutterConfig) -> String {
             let jsonData = try! JSONEncoder().encode(storageConfig)

--- a/ios/Classes/FlutterConfigSerializer.swift
+++ b/ios/Classes/FlutterConfigSerializer.swift
@@ -37,6 +37,9 @@ public struct FlutterConfig: Codable {
 
     /// The client's secret signing key
     public let privateSigKey: String
+    
+    /// The client's email
+    public let email: String?
 
     public init(
         clientName: String,
@@ -47,7 +50,8 @@ public struct FlutterConfig: Codable {
         privateKey: String,
         baseApiUrl: String,
         publicSigKey: String,
-        privateSigKey: String
+        privateSigKey: String,
+        email: String?
     ) {
         self.clientName = clientName
         self.clientId = clientId
@@ -58,6 +62,10 @@ public struct FlutterConfig: Codable {
         self.baseApiUrl = baseApiUrl
         self.publicSigKey = publicSigKey
         self.privateSigKey = privateSigKey
+        
+        /// Config object in e3db-swift does not use an email, but it is expected by Flutter frontend
+        /// Defaults to an empty string if `nil` to resolve error caused by force unwrapping `nil` values
+        self.email = email ?? ""
     }
 
     /// Values for keys that map to what is expected from Flutter Dart client
@@ -71,6 +79,7 @@ public struct FlutterConfig: Codable {
         case baseApiUrl    = "api_url"
         case publicSigKey  = "public_signing_key"
         case privateSigKey = "private_signing_key"
+        case email         = "client_email"
     }
 }
 
@@ -88,7 +97,8 @@ public struct FlutterConfig: Codable {
     ///
     /// - Returns: FlutterConfig
     public static func decodeToFlutterConfig(e3dbConfig: Config) -> FlutterConfig {
-        let config: FlutterConfig = FlutterConfig(clientName: e3dbConfig.clientName, clientId: e3dbConfig.clientId.uuidString, apiKeyId: e3dbConfig.apiKeyId, apiSecret: e3dbConfig.apiSecret, publicKey: e3dbConfig.publicKey, privateKey: e3dbConfig.privateKey, baseApiUrl: e3dbConfig.baseApiUrl.absoluteString, publicSigKey: e3dbConfig.publicSigKey, privateSigKey: e3dbConfig.privateSigKey)
+        /// `email` in `FlutterConfig` constructor set to empty string when decoding Config object because Config does not have an `email` field
+        let config: FlutterConfig = FlutterConfig(clientName: e3dbConfig.clientName, clientId: e3dbConfig.clientId.uuidString, apiKeyId: e3dbConfig.apiKeyId, apiSecret: e3dbConfig.apiSecret, publicKey: e3dbConfig.publicKey, privateKey: e3dbConfig.privateKey, baseApiUrl: e3dbConfig.baseApiUrl.absoluteString, publicSigKey: e3dbConfig.publicSigKey, privateSigKey: e3dbConfig.privateSigKey, email: "")
         return config
     }
  }

--- a/ios/Classes/SwiftFlutterPlugin.swift
+++ b/ios/Classes/SwiftFlutterPlugin.swift
@@ -223,7 +223,7 @@ public class SwiftFlutterPlugin: NSObject, Flutter.FlutterPlugin {
         group.wait()
     }
     
-    // MARK: REGISTER
+    // MARK: REGISTER IDENTITY
     
     public func registerIdentity(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
         let args = call.arguments as! Dictionary<String, Any>
@@ -233,7 +233,7 @@ public class SwiftFlutterPlugin: NSObject, Flutter.FlutterPlugin {
         let email = args["email"] as! String
         let firstName = args["first_name"] as! String
         let lastName = args["last_name"] as! String
-        let emailEACPExpiry: Int! = Int(args["email_eacp_expiry"] as! String) /// e3db-swift expects a `Int` for `realm.register` method
+        let emailEACPExpiry = Int(args["email_eacp_expiry"] as! String)! /// e3db-swift expects an `Int` for `realm.register` method
         
         let realmConfig = args["realm_config"] as! Dictionary<String,String>
         let jsonRealm = try! JSONSerialization.data(withJSONObject: realmConfig, options: .prettyPrinted)
@@ -250,7 +250,9 @@ public class SwiftFlutterPlugin: NSObject, Flutter.FlutterPlugin {
                     result(FlutterError(code: "REGISTER_IDENTITY", message: "register identity failed", details: nil))
                 }
             }
+            group.leave()
         }
+        group.wait()
     }
 
 }


### PR DESCRIPTION
Adds `registerIdentity` method to iOS Plugin, and resolves an emergent bug found in force unwrapping client credentials when the `email` field is `null` due to the Swift SDK's `Config` object not having `email` as a field. 

EDIT: I just realized I named my commits the same thing 🤦 That was unintentional 