### PR TITLE
[WASH-981] Tozny Flutter plugin release 0.0.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,3 +15,8 @@ Upgrade json_serializable to core dependency
 * Add documentation and complete example for use case of creating a TozId Identity for writing file data to TozStore
 * Remove logging of sensitive credentials 
 * Add documentation for how to publish new versions
+
+## 0.0.5
+
+* Add iOS plugin with feature parity with Android plugin
+* Add documentation for how to build and run the iOS plugin and example application

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Use in your Dart or Flutter project by adding `plugin_tozny` as a dependency in 
  plugin_tozny:
    git:
      url: git://github.com/tozny/flutter-plugin
-     ref: 0.0.4
+     ref: 0.0.5
 ```
 
 ### End-to-end TozId Identity Registration, Login, & TozStore encrypted filed storage example

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -38,7 +38,7 @@ android {
             mavenCentral()
         }
 
-        implementation ('com.tozny.e3db:e3db-client-android:7.2.2@aar'){
+        implementation ('com.tozny.e3db:e3db-client-android:7.2.3@aar'){
             transitive = true
         }
         implementation 'com.fasterxml.jackson.core:jackson-core:2.9.0'

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -283,7 +283,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.0.4"
+    version: "0.0.5"
   process:
     dependency: transitive
     description:

--- a/ios/Classes/FlutterAgentTokenSerializer.swift
+++ b/ios/Classes/FlutterAgentTokenSerializer.swift
@@ -1,0 +1,77 @@
+//
+//  FlutterAgentTokenSerializer.swift
+//  plugin_tozny
+//
+//  Created by Matthew Rhea on 8/13/21.
+//
+
+import Foundation
+
+/// Intermediary class to convert `E3db.AgentToken.expiry` from `timeIntervalSinceReferenceDate`
+/// (1 January 2001) to `timeIntervalSince1970`
+public struct IntermediateFlutterAgentToken : Codable {
+    public let accessToken: String
+    
+    public let tokenType: String
+    
+    public let expiry: Date
+    
+    public var expiryAsUnixEpoch: Int?
+        
+    public init(
+        accessToken: String,
+        tokenType: String,
+        expiry: Date
+    ) {
+        self.accessToken = accessToken
+        self.tokenType = tokenType
+        self.expiry = expiry
+    }
+    
+    enum CodingKeys: String, CodingKey {
+        case accessToken = "access_token"
+        case tokenType = "token_type"
+        case expiryAsUnixEpoch = "expiry_unix"
+        case expiry = "expiry"
+    }
+}
+
+extension IntermediateFlutterAgentToken {
+    /// A helper method that returns a `[String: String]` dictionary of the `accessToken`, `tokenType`, and `expiryAsUnixEpoch`
+    /// fields of the `IntermediateFlutterAgentToken` class. This should be used only after `expiryAsUnixEpoch` has been manually set
+    /// as it is an optional field that is unset by `init()`.
+    public static func encodeWithoutDateType(flutterAgentToken: IntermediateFlutterAgentToken) -> [String: String] {
+        var data: [String: String] = [:]
+        data.updateValue(flutterAgentToken.accessToken, forKey: "access_token")
+        data.updateValue(flutterAgentToken.tokenType, forKey: "token_type")
+        data.updateValue(String(flutterAgentToken.expiryAsUnixEpoch!), forKey: "expiry")
+        return data
+    }
+}
+
+/// The target class for `IntermediateFlutterAgentToken`. Use the `init()` instead of
+/// decoding  to `FlutterAgentToken` from `IntermediateFlutterAgentToken` as the two
+/// are incompatible due to their respective `expiry` fields being different types. 
+public struct FlutterAgentToken : Codable {
+    public let accessToken: String
+    
+    public let tokenType: String
+    
+    public let expiry: Int
+    
+    public init(
+        accessToken: String,
+        tokenType: String,
+        expiry: Int
+    ) {
+        self.accessToken = accessToken
+        self.tokenType = tokenType
+        self.expiry = expiry
+    }
+    
+    enum CodingKeys: String, CodingKey {
+        case accessToken = "access_token"
+        case tokenType = "token_type"
+        case expiry
+    }
+}

--- a/lib/tozny_model.dart
+++ b/lib/tozny_model.dart
@@ -219,7 +219,7 @@ class AgentToken {
   @JsonKey(name: "token_type")
   String tokenType;
   @JsonKey(name: "expiry")
-  double expiry;
+  int expiry;
 
   AgentToken(
     this.accessToken,

--- a/lib/tozny_model.g.dart
+++ b/lib/tozny_model.g.dart
@@ -198,7 +198,7 @@ AgentToken _$AgentTokenFromJson(Map<String, dynamic> json) {
     final val = AgentToken(
       $checkedConvert(json, 'access_token', (v) => v as String),
       $checkedConvert(json, 'token_type', (v) => v as String),
-      $checkedConvert(json, 'expiry', (v) => v as double),
+      $checkedConvert(json, 'expiry', (v) => v as int),
     );
     return val;
   }, fieldKeyMap: const {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: plugin_tozny
 description: Tozny flutter plugin to communicate with native SDKs.
-version: 0.0.4
+version: 0.0.5
 homepage: https://github.com/tozny/flutter-plugin
 
 environment:


### PR DESCRIPTION
How could 🍎 do this. 

- Updates the Android plugin's `build.gradle` to use the recently released version 7.2.3
- Updates the iOS plugin to return a Unix timestamp beginning 1 January 1970 instead of 1 January 2001 
- Updates Tozny's `AgentToken` model to expect an Int for the expiry field of an AgentToken
- Updates Tozny's Flutter plugin to be ready for release 0.0.5 by running `flutter pub publish --dry-run`