### PR TITLE
[WASH1030] Update gradle, minSdkVersion; release 0.0.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,3 +20,8 @@ Upgrade json_serializable to core dependency
 
 * Add iOS plugin with feature parity with Android plugin
 * Add documentation for how to build and run the iOS plugin and example application
+
+## 0.0.6
+
+* Upgrade gradle to 4.2
+* Change minimum support SDK version to 26

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Use in your Dart or Flutter project by adding `plugin_tozny` as a dependency in 
  plugin_tozny:
    git:
      url: git://github.com/tozny/flutter-plugin
-     ref: 0.0.5
+     ref: 0.0.6
 ```
 
 ### End-to-end TozId Identity Registration, Login, & TozStore encrypted filed storage example

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -26,7 +26,7 @@ android {
     compileSdkVersion 29
 
     defaultConfig {
-        minSdkVersion 23
+        minSdkVersion 26
         targetSdkVersion 29
     }
     lintOptions {

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,6 +1,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
   package="com.example.plugin_tozny">
-    <uses-sdk android:minSdkVersion="23"
+    <uses-sdk
         android:targetSdkVersion="29"
          />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -33,7 +33,7 @@ android {
 
     defaultConfig {
         applicationId "com.tozny.plugin_tozny"
-        minSdkVersion 23
+        minSdkVersion 26
         targetSdkVersion 29
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.5.0'
+        classpath 'com.android.tools.build:gradle:4.2.2'
     }
 }
 

--- a/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-all.zip

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -283,7 +283,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.0.5"
+    version: "0.0.6"
   process:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: plugin_tozny
 description: Tozny flutter plugin to communicate with native SDKs.
-version: 0.0.5
+version: 0.0.6
 homepage: https://github.com/tozny/flutter-plugin
 
 environment:


### PR DESCRIPTION
- Removed minSdk version from the manifest & tested the methods against multiple devices & sdk versions

~~Note: We currently have the minSdkVersion set to 23 in the build.gradle file; however, RegisterIdentity fails for API version 25 & lower. This is unrelated to changing the manifest file. I'm not sure if I should update the minSdkVersion, or try to find the cause & make it compatible with lower api versions?~~ I have updated the minSdkVersion to 26 in the build.gradle files.